### PR TITLE
Remove dependency on the fileutils gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-- nothing
+- Remove dependency on the fileutils gem
 
 ## [0.0.3] - 2015-10-22
 ### Changed

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -17,7 +17,6 @@
 #
 # DEPENDENCIES:
 #   gem: sensu-plugin
-#   gem: fileutils
 #
 # USAGE:
 #   #YELLOW

--- a/bin/handler-logevent.rb
+++ b/bin/handler-logevent.rb
@@ -8,8 +8,8 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE for details.
 
 require 'sensu-handler'
-require 'json'
 require 'fileutils'
+require 'json'
 
 class LogEvent < Sensu::Handler
   def handle

--- a/sensu-plugins-logs.gemspec
+++ b/sensu-plugins-logs.gemspec
@@ -39,7 +39,6 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsLogs::Version::VER_STRING
 
-  s.add_runtime_dependency 'fileutils', '0.7'
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'


### PR DESCRIPTION
The FileUtils in use in this project is a part of Ruby. The fileutils
gem appears to be something separate that, in turn,  creates an
unnecessary dependency on ImageMagick.
