### PR TITLE
Drop non-ASCII chars from log line

### DIFF
--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -180,7 +180,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
     @log.seek(@bytes_to_skip, File::SEEK_SET) if @bytes_to_skip > 0
     # #YELLOW
     @log.each_line do |line|
-      line = line.encode('UTF-8', :invalid => :replace, :undef => :replace)
+      line = line.encode('UTF-8', invalid: :replace, replace: '') 
       bytes_read += line.bytesize
       if config[:case_insensitive]
         m = line.downcase.match(config[:pattern].downcase) unless line.match(config[:exclude])

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -180,6 +180,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
     @log.seek(@bytes_to_skip, File::SEEK_SET) if @bytes_to_skip > 0
     # #YELLOW
     @log.each_line do |line|
+      line = line.encode('UTF-8', :invalid => :replace, :undef => :replace)
       bytes_read += line.bytesize
       if config[:case_insensitive]
         m = line.downcase.match(config[:pattern].downcase) unless line.match(config[:exclude])

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -180,7 +180,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
     @log.seek(@bytes_to_skip, File::SEEK_SET) if @bytes_to_skip > 0
     # #YELLOW
     @log.each_line do |line|
-      line = line.encode('UTF-8', invalid: :replace, replace: '') 
+      line = line.encode('UTF-8', invalid: :replace, replace: '')
       bytes_read += line.bytesize
       if config[:case_insensitive]
         m = line.downcase.match(config[:pattern].downcase) unless line.match(config[:exclude])


### PR DESCRIPTION
### Issues fixed

Fixes Issue #[802](https://github.com/sensu/sensu-community-plugins/issues/802)
#### General

Replaces invalid UTF-8 characters in a log line.
Fixes issue "invalid byte sequence in US-ASCII in check-log.rb:185:in 'match'"
##### How to reproduce

Influxdb uses µ character in logs which breaks the plugin. Here is a line from log:
`[meta] 2016/03/16 17:54:41 127.0.0.1 - - [16/Mar/2016:17:54:41 +0000] GET /lease?name=continuous_querier&nodeid=0 HTTP/1.1 200 105 - Go 1.1 package http 28c16962-eba0-11e5-aac8-000000000000 283.339µs`

Error message from sensu-server log:
`Check failed to run: invalid byte sequence in US-ASCII, ["/var/lib/gems/1.9.1/gems/sensu-plugins-logs-0.0.4/bin/check-log.rb:185:in`match'", "/var/lib/gems/1.9.1/gems/sensu-plugins-logs-0.0.4/bin/check-log.rb:185:in `match'", "/var/lib/gems/1.9.1/gems/sensu-plugins-logs-0.0.4/bin/check-log.rb:185:in`block in search_log'", "/var/lib/gems/1.9.1/gems/sensu-plugins-logs-0.0.4/bin/check-log.rb:182:in `each_line'", "/var/lib/gems/1.9.1/gems/sensu-plugins-logs-0.0.4/bin/check-log.rb:182:in`search_log'", "/var/lib/gems/1.9.1/gems/sensu-plugins-logs-0.0.4/bin/check-log.rb:134:in `block in run'", "/var/lib/gems/1.9.1/gems/sensu-plugins-logs-0.0.4/bin/check-log.rb:128:in`each'", "/var/lib/gems/1.9.1/gems/sensu-plugins-logs-0.0.4/bin/check-log.rb:128:in `run'", "/var/lib/gems/1.9.1/gems/sensu-plugin-1.2.0/lib/sensu-plugin/cli.rb:56:in`block in class:CLI'"]`
