### PR TITLE
Write state file atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - Add `return-length` option to support custom length for returned matched lines
 
+### Fixed
+- Write the state file atomically
+
 ## [1.0.0] - 2017-03-07
 ### Fixed
 - `check-log.rb`: Drop non-ASCII chars from log line (@vlinevich)

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -169,7 +169,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
     @state_file = File.join(state_dir, File.expand_path(log_file).sub(/^([A-Z]):\//, '\1/'))
     @bytes_to_skip = begin
       File.open(@state_file) do |file|
-        file.flock(File::LOCK_SH)
+        file.flock(File::LOCK_SH) unless Gem.win_platform?
         file.readline.to_i
       end
     rescue
@@ -214,7 +214,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
     end
     FileUtils.mkdir_p(File.dirname(@state_file))
     File.open(@state_file, File::RDWR | File::CREAT, 0644) do |file|
-      file.flock(File::LOCK_EX)
+      file.flock(File::LOCK_EX) unless Gem.win_platform?
       file.write(@bytes_to_skip + bytes_read)
     end
     [n_warns, n_crits, accumulative_error]


### PR DESCRIPTION
If you have two different calls of this script on the same file, one of
the runs may be at the point of "truncate" when writing the state
file. If the other run is trying to read, that will raise and the
default is rescue with 0. This means that your check will bounce between
OK and critical/warning depending if these runs happen to stomp one
another.

**NOTE:** The downside is that we use flock and that isn't supported in all platforms. Not sure how many targets these scripts are intended to run on, so feel free to reject on that base.
