### PR TITLE
Add  support to read and match pattern against whole log entry instead of a single line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - Add `return-length` option to support custom length for returned matched lines
+- Add `log-pattern` option to support read and match against whole log entry instead of single line
 
 ## [1.0.0] - 2017-03-07
 ### Fixed

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -192,7 +192,6 @@ class CheckLog < Sensu::Plugin::Check::CLI
     @log.seek(@bytes_to_skip, File::SEEK_SET) if @bytes_to_skip > 0
     # #YELLOW
     @log.each_line do |line|
-
       if config[:log_pattern]
         line = get_log_entry(line)
       end
@@ -235,12 +234,12 @@ class CheckLog < Sensu::Plugin::Check::CLI
       if !line.match(config[:log_pattern])
         log_entry.push(line)
       else
-        @log.pos = @log.pos - line.bytesize unless !line
+        @log.pos = @log.pos - line.bytesize if line
         break
       end
     end
 
-    log_entry = log_entry.join("")
+    log_entry = log_entry.join('')
     log_entry
   end
 end

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -57,6 +57,16 @@ class CheckLog < Sensu::Plugin::Check::CLI
          short: '-q PAT',
          long: '--pattern PAT'
 
+  # this check currently makes no attempt to try to save you from
+  # a bad regex such as being unbound. Regexes ending in anything like:
+  # `.*`, `.+`, `[0-9-A-Z-a-z]+`, etc. Having regex without a real
+  # boundry could force the entire log file into memory at once rather
+  # line by line and could have signifigant performance impact. Please
+  # if you are going to use this please make sure you have log rotation
+  # set up and test your regex to make sure that it will catch what
+  # you want. I would reccomend placing several log examples into
+  # something like http://regexr.com/ and ensure that your regex properly
+  # catches the boundries. You have been warned.
   option :log_pattern,
          description: 'The log format of each log entry',
          short: '-l PAT',

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -57,6 +57,11 @@ class CheckLog < Sensu::Plugin::Check::CLI
          short: '-q PAT',
          long: '--pattern PAT'
 
+  option :log_pattern,
+         description: 'The log format of each log entry',
+         short: '-l PAT',
+         long: '--log-pattern PAT'
+
   option :exclude,
          description: 'Pattern to exclude from matching',
          short: '-E PAT',
@@ -187,6 +192,11 @@ class CheckLog < Sensu::Plugin::Check::CLI
     @log.seek(@bytes_to_skip, File::SEEK_SET) if @bytes_to_skip > 0
     # #YELLOW
     @log.each_line do |line|
+
+      if config[:log_pattern]
+        line = get_log_entry(line)
+      end
+
       line = line.encode('UTF-8', invalid: :replace, replace: '')
       bytes_read += line.bytesize
       if config[:case_insensitive]
@@ -216,5 +226,21 @@ class CheckLog < Sensu::Plugin::Check::CLI
       file.write(@bytes_to_skip + bytes_read)
     end
     [n_warns, n_crits, accumulative_error]
+  end
+
+  def get_log_entry(first_line)
+    log_entry = [first_line]
+
+    @log.each_line do |line|
+      if !line.match(config[:log_pattern])
+        log_entry.push(line)
+      else
+        @log.pos = @log.pos - line.bytesize unless !line
+        break
+      end
+    end
+
+    log_entry = log_entry.join("")
+    log_entry
   end
 end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
[#18](https://github.com/sensu-plugins/sensu-plugins-logs/issues/18)

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Add the ability to read and match whole log entry in the log file instead of single line.

#### Known Compatablity Issues

