### PR TITLE
Add `return-length` option to support custom length for returned content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- Add `log-pattern` option to support read and match against whole log entry instead of single line
 
 ## [1.0.0] - 2017-03-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
 - Add `log-pattern` option to support read and match against whole log entry instead of single line
 
 ## [1.0.0] - 2017-03-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - Add `log-pattern` option to support read and match against whole log entry instead of single line
+- Add `return-length` option to support custom length for returned matched lines
 
 ## [1.0.0] - 2017-03-07
 ### Fixed

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -111,6 +111,13 @@ class CheckLog < Sensu::Plugin::Check::CLI
          boolean: true,
          default: false
 
+  option :return_content_length,
+         description: 'Matched line length',
+         short: '-L N',
+         long: '--return-length N',
+         proc: proc(&:to_i),
+         default: 250
+
   def run
     unknown 'No log file specified' unless config[:log_file] || config[:file_pattern]
     unknown 'No pattern specified' unless config[:pattern]
@@ -197,7 +204,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
         m = line.match(config[:pattern]) unless line.match(config[:exclude])
       end
       if m
-        accumulative_error += "\n" + line.slice(0, 250)
+        accumulative_error += "\n" + line.slice(0..config[:return_content_length])
         if m[1]
           if config[:crit] && m[1].to_i > config[:crit]
             n_crits += 1

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -185,7 +185,6 @@ class CheckLog < Sensu::Plugin::Check::CLI
     @log.seek(@bytes_to_skip, File::SEEK_SET) if @bytes_to_skip > 0
     # #YELLOW
     @log.each_line do |line|
-
       if config[:log_pattern]
         line = get_log_entry(line)
       end
@@ -228,12 +227,12 @@ class CheckLog < Sensu::Plugin::Check::CLI
       if !line.match(config[:log_pattern])
         log_entry.push(line)
       else
-        @log.pos = @log.pos - line.bytesize unless !line
+        @log.pos = @log.pos - line.bytesize if line
         break
       end
     end
 
-    log_entry = log_entry.join("")
+    log_entry = log_entry.join('')
     log_entry
   end
 end

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -57,6 +57,11 @@ class CheckLog < Sensu::Plugin::Check::CLI
          short: '-q PAT',
          long: '--pattern PAT'
 
+  option :log_pattern,
+         description: 'The log format of each log entry',
+         short: '-l PAT',
+         long: '--log-pattern PAT'
+
   option :exclude,
          description: 'Pattern to exclude from matching',
          short: '-E PAT',
@@ -180,6 +185,11 @@ class CheckLog < Sensu::Plugin::Check::CLI
     @log.seek(@bytes_to_skip, File::SEEK_SET) if @bytes_to_skip > 0
     # #YELLOW
     @log.each_line do |line|
+
+      if config[:log_pattern]
+        line = get_log_entry(line)
+      end
+
       line = line.encode('UTF-8', invalid: :replace, replace: '')
       bytes_read += line.bytesize
       if config[:case_insensitive]
@@ -209,5 +219,21 @@ class CheckLog < Sensu::Plugin::Check::CLI
       file.write(@bytes_to_skip + bytes_read)
     end
     [n_warns, n_crits, accumulative_error]
+  end
+
+  def get_log_entry(first_line)
+    log_entry = [first_line]
+
+    @log.each_line do |line|
+      if !line.match(config[:log_pattern])
+        log_entry.push(line)
+      else
+        @log.pos = @log.pos - line.bytesize unless !line
+        break
+      end
+    end
+
+    log_entry = log_entry.join("")
+    log_entry
   end
 end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Add `return-length` option to support custom length for returned content

#### Known Compatablity Issues

