### PR TITLE
Add  option to support custom length for returned content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Add `return-length` option to support custom length for returned matched lines
 
 ## [1.0.0] - 2017-03-07
 ### Fixed

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -106,6 +106,13 @@ class CheckLog < Sensu::Plugin::Check::CLI
          boolean: true,
          default: false
 
+  option :return_content_length,
+         description: 'Matched line length',
+         short: '-L N',
+         long: '--return-length N',
+         proc: proc(&:to_i),
+         default: 250
+
   def run
     unknown 'No log file specified' unless config[:log_file] || config[:file_pattern]
     unknown 'No pattern specified' unless config[:pattern]
@@ -188,7 +195,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
         m = line.match(config[:pattern]) unless line.match(config[:exclude])
       end
       if m
-        accumulative_error += "\n" + line.slice(0, 250)
+        accumulative_error += "\n" + line.slice(0..config[:return_content_length])
         if m[1]
           if config[:crit] && m[1].to_i > config[:crit]
             n_crits += 1


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Add  option to support custom length for returned content

#### Known Compatablity Issues

