### PR TITLE
Add 'return-error-limit' option to limit the number of returned matched lines\log entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Added
-- Add `return-error-limit` option to limit the number of returned matched lines(log entries) (@jhshadi)
+- Add `return-error-limit` option to limit the number of returned matched lines\"log entries" (@jhshadi)
 - ruby 2.4 testing (@majormoses)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Added
+- Add `return-error-limit` option to limit the number of returned matched lines\log entries (@jhshadi)
 - ruby 2.4 testing (@majormoses)
 
 ### Fixed
@@ -24,8 +25,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [1.1.0] - 2017-05-20
 ### Added
-- Add `return-length` option to support custom length for returned matched lines
-- Add `log-pattern` option to support read and match against whole log entry instead of single line
+- Add `return-length` option to support custom length for returned matched lines (@jhshadi)
+- Add `log-pattern` option to support read and match against whole log entry instead of single line (@jhshadi)
 
 ## [1.0.0] - 2017-03-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Added
-- Add `return-error-limit` option to limit the number of returned matched lines\"log entries" (@jhshadi)
+- Add `return-error-limit` option to limit the number of returned matched lines (log entries) (@jhshadi)
 - ruby 2.4 testing (@majormoses)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Added
-- Add `return-error-limit` option to limit the number of returned matched lines\log entries (@jhshadi)
+- Add `return-error-limit` option to limit the number of returned matched lines\"log entries" (@jhshadi)
 - ruby 2.4 testing (@majormoses)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Added
-- Add `return-error-limit` option to limit the number of returned matched lines\"log entries" (@jhshadi)
+- Add `return-error-limit` option to limit the number of returned matched lines(log entries) (@jhshadi)
 - ruby 2.4 testing (@majormoses)
 
 ### Fixed

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -129,9 +129,8 @@ class CheckLog < Sensu::Plugin::Check::CLI
          default: 250
 
   option :return_error_limit,
-         description: 'Max number of returned matched lines(log entries)',
-         short: '-M N',
-         long: '--return-error-limit N',
+         description: 'Max number of returned matched lines\"log entries"',
+         short: '-M N', long: '--return-error-limit N',
          proc: proc(&:to_i)
 
   # Use this option when you expecting your log lines to contain invalid byte sequence in utf-8.

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -129,8 +129,9 @@ class CheckLog < Sensu::Plugin::Check::CLI
          default: 250
 
   option :return_error_limit,
-         description: 'Max number of returned matched lines\"log entries"',
-         short: '-M N', long: '--return-error-limit N',
+         description: 'Max number of returned matched lines(log entries)',
+         short: '-M N',
+         long: '--return-error-limit N',
          proc: proc(&:to_i)
 
   # Use this option when you expecting your log lines to contain invalid byte sequence in utf-8.

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -129,7 +129,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
          default: 250
 
   option :return_error_limit,
-         description: 'Max number of returned matched lines\log entries',
+         description: 'Max number of returned matched lines\"log entries"',
          short: '-M N', long: '--return-error-limit N',
          proc: proc(&:to_i)
 

--- a/bin/check-log.rb
+++ b/bin/check-log.rb
@@ -128,6 +128,11 @@ class CheckLog < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          default: 250
 
+  option :return_error_limit,
+         description: 'Max number of returned matched lines\log entries',
+         short: '-M N', long: '--return-error-limit N',
+         proc: proc(&:to_i)
+
   # Use this option when you expecting your log lines to contain invalid byte sequence in utf-8.
   # https://github.com/sensu-plugins/sensu-plugins-logs/pull/26
   option :encode_utf16,
@@ -229,7 +234,9 @@ class CheckLog < Sensu::Plugin::Check::CLI
         m = line.match(config[:pattern]) unless line.match(config[:exclude])
       end
       if m
-        accumulative_error += "\n" + line.slice(0..config[:return_content_length])
+        if !config[:return_error_limit] || (config[:return_error_limit] && n_matched < config[:return_error_limit])
+          accumulative_error += "\n" + line.slice(0..config[:return_content_length])
+        end
         n_matched += 1
       end
     end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
#28 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
limit the number of returned matched lines\log entries.

#### Known Compatibility Issues
