### PR TITLE
Update to require sensu-plugin 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ before_install:
 install:
 - bundle install
 rvm:
-- 2.1
-- 2.2
 - 2.3.0
 - 2.4.1
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.1
-    rvm: 2.2
     rvm: 2.3.0
     rvm: 2.4.1
     repo: sensu-plugins/sensu-plugins-logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 ### Added
-- use unreleased version of sensu-plugin with 2.x to 1.x migration option
+- updateed to use sensu-plugin 2.7 with 2.x to 1.x migration option
 
 ### Fixed
 - check-log.rb: pattern is now required via option config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 ## [Unreleased]
 ### Added
 - updated to use sensu-plugin 2.7 with 2.x to 1.x migration option
-### Changed
+### Breaking Changes
 - require ruby 2.3.0 or greater, resolves issues with dependancies 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 ### Added
-- updateed to use sensu-plugin 2.7 with 2.x to 1.x migration option
+- updated to use sensu-plugin 2.7 with 2.x to 1.x migration option
+### Changed
+- require ruby 2.3.0 or greater, resolves issues with dependancies 
 
 ### Fixed
 - check-log.rb: pattern is now required via option config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- use unreleased version of sensu-plugin with 2.x to 1.x migration option
+
 ### Fixed
 - check-log.rb: pattern is now required via option config
 - check-log.rb: update descriptions of crit and warn options

--- a/lib/sensu-plugins-logs/version.rb
+++ b/lib/sensu-plugins-logs/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsLogs
   module Version
     MAJOR = 1
     MINOR = 3
-    PATCH = 2
+    PATCH = 3
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/lib/sensu-plugins-logs/version.rb
+++ b/lib/sensu-plugins-logs/version.rb
@@ -1,8 +1,8 @@
 module SensuPluginsLogs
   module Version
-    MAJOR = 1
-    MINOR = 3
-    PATCH = 3
+    MAJOR = 2
+    MINOR = 0
+    PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sensu-plugins-logs.gemspec
+++ b/sensu-plugins-logs.gemspec
@@ -25,12 +25,12 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.1'
+  s.required_ruby_version  = '>= 2.0'
   s.summary                = 'Sensu plugins for logs'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsLogs::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 2.6'
+  s.add_runtime_dependency 'sensu-plugin', '~> 2.7'
 
   s.add_development_dependency 'bundler',                   '~> 1.15'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'

--- a/sensu-plugins-logs.gemspec
+++ b/sensu-plugins-logs.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsLogs::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin', '~> 2.6'
 
   s.add_development_dependency 'bundler',                   '~> 1.15'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'

--- a/sensu-plugins-logs.gemspec
+++ b/sensu-plugins-logs.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.1'
+  s.required_ruby_version  = '>= 2.3'
   s.summary                = 'Sensu plugins for logs'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsLogs::Version::VER_STRING

--- a/sensu-plugins-logs.gemspec
+++ b/sensu-plugins-logs.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0'
+  s.required_ruby_version  = '>= 2.1'
   s.summary                = 'Sensu plugins for logs'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsLogs::Version::VER_STRING

--- a/sensu-plugins-logs.gemspec
+++ b/sensu-plugins-logs.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.1'
+  s.required_ruby_version  = '>= 2.0'
   s.summary                = 'Sensu plugins for logs'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsLogs::Version::VER_STRING


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Update the gemspec to use sensu-plugin  2.7 which includes the logic to map sensu 2 events into sensu 1.5 events for handlers and mutators based on the sensu-plugin Handler and Mutator classes.

#### Known Compatibility Issues
